### PR TITLE
some modifications

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ bandit~=1.7.2
 mypy~=1.3.0
 isort~=5.10.1
 typing_extensions<4.6.0
+pyjwt~=2.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     browsepy >=0.5.6
     art
     typing_extensions<4.6.0
+    pyjwt >=2.6.0
 
 package_dir =
     = src

--- a/src/powerpwn/cli/arguments.py
+++ b/src/powerpwn/cli/arguments.py
@@ -9,6 +9,7 @@ from powerpwn.powerdump.utils.const import CACHE_PATH
 def module_gui(sub_parser: argparse.ArgumentParser):
     gui_parser = sub_parser.add_parser("gui", description="Show collected resources and data.", help="Show collected resources and data via GUI.")
     gui_parser.add_argument("--cache-path", default=CACHE_PATH, type=str, help="Path to cached resources.")
+    gui_parser.add_argument("-t", "--tenant", required=False, type=str, help="Tenant id to launch gui.")
 
 
 def module_dump(sub_parser: argparse.ArgumentParser):
@@ -19,6 +20,7 @@ def module_dump(sub_parser: argparse.ArgumentParser):
     dump_parser.add_argument("--cache-path", default=CACHE_PATH, help="Path to store collected resources and data.")
     dump_parser.add_argument("-t", "--tenant", required=False, type=str, help="Tenant id to connect.")
     dump_parser.add_argument("-g", "--gui", action="store_true", help="Run local server for gui.")
+    dump_parser.add_argument("-r", "--recon", action="store_true", help="Run recon before dump. Should be used if recon command was not run before.")
 
 
 def module_recon(sub_parser: argparse.ArgumentParser):

--- a/src/powerpwn/cli/runners.py
+++ b/src/powerpwn/cli/runners.py
@@ -16,12 +16,15 @@ from powerpwn.powerdump.gui.gui import Gui
 from powerpwn.powerdump.utils.auth import Auth, acquire_token, acquire_token_from_cached_refresh_token, get_cached_tenant
 from powerpwn.powerdump.utils.const import API_HUB_SCOPE, POWER_APPS_SCOPE
 from powerpwn.powerdump.utils.path_utils import collected_data_path, entities_path
+from powerpwn.powerdump.utils.token_cache import clear_token_cache
 from powerpwn.powerphishing.app_installer import AppInstaller
 
 logger = logging.getLogger(LOGGER_NAME)
 
 
 def __init_command_token(args, scope: str) -> Auth:
+    if args.clear_cache:
+        clear_token_cache()
 
     # if cached refresh token is found, use it
     if auth := acquire_token_from_cached_refresh_token(scope, args.tenant):

--- a/src/powerpwn/cli/runners.py
+++ b/src/powerpwn/cli/runners.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(LOGGER_NAME)
 def __init_command_token(args, scope: str) -> Auth:
     if args.clear_cache:
         clear_token_cache()
+        return acquire_token(scope=scope, tenant=args.tenant)
 
     # if cached refresh token is found, use it
     if auth := acquire_token_from_cached_refresh_token(scope, args.tenant):

--- a/src/powerpwn/main.py
+++ b/src/powerpwn/main.py
@@ -29,8 +29,14 @@ def main():
 
     if command == "dump":
         run_dump_command(args)
+        if args.gui:
+            logger.info("Going to run local server for gui")
+            run_gui_command(args)
     elif command == "recon":
         run_recon_command(args)
+        if args.gui:
+            logger.info("Going to run local server for gui")
+            run_gui_command(args)
     elif command == "gui":
         run_gui_command(args)
     elif command == "backdoor":

--- a/src/powerpwn/powerdump/collect/resources_collectors/connectors_collector.py
+++ b/src/powerpwn/powerdump/collect/resources_collectors/connectors_collector.py
@@ -27,6 +27,9 @@ class ConnectorsCollector(IResourceCollector):
                 if "403" in str(e):
                     logger.warning(f"User doesn't have access to custom connector spec for connector_id={connector_id}. Skipping spec.")
                     continue
+                elif "400" in str(e):
+                    logger.error(f"Failed to get connector {connector_id} for connection {self.__connector_id_to_connection_ids[connector_id]}")
+                    continue
                 raise e
 
             swagger = connector["properties"]["swagger"]

--- a/src/powerpwn/powerdump/gui/gui.py
+++ b/src/powerpwn/powerdump/gui/gui.py
@@ -7,6 +7,7 @@ from flask import Flask
 
 from powerpwn.cli.const import LOGGER_NAME
 from powerpwn.powerdump.gui.prep import (
+    env_resources_table_wrapper,
     flt_connection_table_wrapper,
     flt_resource_wrapper,
     full_canvasapps_table_wrapper,
@@ -27,12 +28,13 @@ class Gui:
         app = Flask(__name__, template_folder=self.__get_template_full_path())
         register_specs(app=app, cache_path=cache_path)
         app.route("/")(full_resources_table_wrapper(cache_path=cache_path))
+        app.route("/env/<env_id>")(env_resources_table_wrapper(cache_path=cache_path))
         app.route("/credentials")(full_connection_table_wrapper(cache_path=cache_path))
         app.route("/automation")(full_logic_flows_table_wrapper(cache_path=cache_path))
         app.route("/app/")(full_canvasapps_table_wrapper(cache_path))
         app.route("/connector/")(full_connectors_table_wrapper(cache_path))
-        app.route("/<connector_id>/")(flt_connection_table_wrapper(cache_path=cache_path))
-        app.route("/<resource_type>/<env_id>/<resource_id>")(flt_resource_wrapper(cache_path=cache_path))
+        app.route("/credentials/<connector_id>/")(flt_connection_table_wrapper(cache_path=cache_path))
+        app.route("/env/<env_id>/<resource_type>/<resource_id>")(flt_resource_wrapper(cache_path=cache_path))
 
         logger = logging.getLogger(LOGGER_NAME)
         logger.info("Application is running on http://127.0.0.1:5000")

--- a/src/powerpwn/powerdump/gui/prep.py
+++ b/src/powerpwn/powerdump/gui/prep.py
@@ -51,6 +51,15 @@ def full_resources_table_wrapper(cache_path: str):
     return full_resources_table
 
 
+def env_resources_table_wrapper(cache_path: str):
+    def env_resources_table(env_id: str):
+        resources = list(load_resources(cache_path=cache_path, env_id=env_id))
+
+        return render_template("resources_table.html", title=f"{TOOL_NAME} - environment {env_id}", resources=resources)
+
+    return env_resources_table
+
+
 def full_connection_table_wrapper(cache_path: str):
     def full_connection_table():
         connections = list(load_connections(cache_path=cache_path, with_logic_flows=False))
@@ -101,7 +110,7 @@ def flt_resource_wrapper(cache_path: str):
         resource: Optional[ResourceEntityBase] = None
         if resource_type == "app":
             resource = get_canvasapp(cache_path, env_id, resource_id)
-        elif resource_type in ("credentials", "automation"):
+        elif resource_type in ("credentials", "automation", "connection"):
             resource = get_connection(cache_path, env_id, resource_id)
         elif resource_type == "connector":
             resource = get_connector(cache_path, env_id, resource_id)

--- a/src/powerpwn/powerdump/gui/templates/canvasapps_table.html
+++ b/src/powerpwn/powerdump/gui/templates/canvasapps_table.html
@@ -22,7 +22,7 @@
           <td>{{ canvasapp.created_at }}</td>
           <td>{{ canvasapp.last_modified_at }}</td>
           <td><a href="{{ canvasapp.run_url }}" target="_blank">Run</a> </td>
-          <td><a href="/app/{{ canvasapp.environment_id }}/{{ canvasapp.entity_id }}">Raw</a> </td>
+          <td><a href="/env/{{ canvasapp.environment_id }}/app/{{ canvasapp.entity_id }}">Raw</a> </td>
         </tr>
       {% endfor %}
     </tbody>

--- a/src/powerpwn/powerdump/gui/templates/connections_table.html
+++ b/src/powerpwn/powerdump/gui/templates/connections_table.html
@@ -19,7 +19,7 @@
       {% for connection in resources %}
         <tr>
           <td><img src="{{ connection.icon_uri }}" class="img-thumbnail" alt="{{ connection.connection_id }}" width="25"></td>
-          <td><a href="/{{ connection.connector_id }}">{{ connection.connector_id }}</a></td>
+          <td><a href="/credentials/{{ connection.connector_id }}">{{ connection.connector_id }}</a></td>
           <td>{{ connection.display_name }}</td>
           <td>{{ connection.environment_id }}</td>
           <td>{{ connection.is_valid }}</td>
@@ -28,7 +28,7 @@
           <td>{{ connection.created_by.email }}</td>
           <td>{{ connection.shareable }}</td>
           <td><a href="/api/{{ connection.connector_id }}/{{ connection.connection_id }}">Playground</a></td>
-          <td><a href="/credentials/{{ connection.environment_id }}/{{ connection.entity_id }}">Raw</a> </td>
+          <td><a href="/env/{{ connection.environment_id }}/credentials/{{ connection.entity_id }}">Raw</a> </td>
           <td><a href="http://127.0.0.1:8080/browse/data/{{ connection.environment_id }}/connections/{{connection.connector_id}}/{{connection.entity_id}}" target="_blank">Dump</a> </td>
         </tr>
       {% endfor %}

--- a/src/powerpwn/powerdump/gui/templates/connectors_table.html
+++ b/src/powerpwn/powerdump/gui/templates/connectors_table.html
@@ -19,7 +19,7 @@
           <td>{{ connector.created_by }}</td>
           <td>{{ connector.created_at }}</td>
           <td>{{ connector.last_modified_at }}</td>
-          <td><a href="/{{ connector.entity_type}}/{{ connector.environment_id }}/{{ connector.entity_id }}">Raw</a> </td>
+          <td><a href="/env/{{ connector.environment_id }}/{{ connector.entity_type}}/{{ connector.entity_id }}">Raw</a> </td>
         </tr>
       {% endfor %}
     </tbody>

--- a/src/powerpwn/powerdump/gui/templates/logic_flows_table.html
+++ b/src/powerpwn/powerdump/gui/templates/logic_flows_table.html
@@ -28,7 +28,7 @@
           <td>{{ connection.created_by.email }}</td>
           <td>{{ connection.shareable }}</td>
           <td><a href="/api/{{ connection.connector_id }}/{{ connection.connection_id }}">Playground</a></td>
-          <td><a href="/automation/{{ connection.environment_id }}/{{ connection.entity_id }}">Raw</a> </td>
+          <td><a href="/env/{{ connection.environment_id }}/automation/{{ connection.entity_id }}">Raw</a> </td>
         </tr>
       {% endfor %}
     </tbody>

--- a/src/powerpwn/powerdump/gui/templates/logic_flows_table.html
+++ b/src/powerpwn/powerdump/gui/templates/logic_flows_table.html
@@ -5,28 +5,22 @@
     <thead>
       <tr>
         <th></th>
-        <th>Connector</th>
-        <th>Connection</th>
+        <th>Automation</th>
         <th>Environment </th>
-        <th>Is valid</th>
-        <th>Last modified at</th>
-        <th>Expires at</th>
+        <th>Created at</th>
         <th>Created by</th>
-        <th>Shareable</th>
+        <th>Last modified at</th>
       </tr>
     </thead>
     <tbody>
       {% for connection in resources %}
         <tr>
           <td><img src="{{ connection.icon_uri }}" class="img-thumbnail" alt="{{ connection.connection_id }}" width="25"></td>
-          <td><a href="/{{ connection.connector_id }}">{{ connection.connector_id }}</a></td>
           <td>{{ connection.display_name }}</td>
           <td>{{ connection.environment_id }}</td>
-          <td>{{ connection.is_valid }}</td>
-          <td>{{ connection.last_modified_at }}</td>
-          <td>{{ connection.expiration_time }}</td>
+          <td>{{ connection.created_at }}</td>
           <td>{{ connection.created_by.email }}</td>
-          <td>{{ connection.shareable }}</td>
+          <td>{{ connection.last_modified_at }}</td>
           <td><a href="/api/{{ connection.connector_id }}/{{ connection.connection_id }}">Playground</a></td>
           <td><a href="/env/{{ connection.environment_id }}/automation/{{ connection.entity_id }}">Raw</a> </td>
         </tr>

--- a/src/powerpwn/powerdump/gui/templates/resources_table.html
+++ b/src/powerpwn/powerdump/gui/templates/resources_table.html
@@ -19,11 +19,11 @@
           <td>{{ resource.display_name }} </td>
           <td>{{ resource.entity_id }}</td>
           <td>{{ resource.entity_type }}</td>
-          <td>{{ resource.environment_id }}</td>
+          <td><a href="/env/{{ resource.environment_id }}">{{ resource.environment_id }}</a> </td>
           <td>{{ resource.created_by.email }}</td>
           <td>{{ resource.created_at }}</td>
           <td>{{ resource.last_modified_at }}</td>
-          <td><a href="/connector/{{ resource.environment_id }}/{{ resource.entity_id }}">Raw</a> </td>
+          <td><a href="/env/{{ resource.environment_id }}/{{resource.entity_type}}/{{ resource.entity_id }}">Raw</a> </td>
         </tr>
       {% endfor %}
     </tbody>

--- a/src/powerpwn/powerdump/utils/auth.py
+++ b/src/powerpwn/powerdump/utils/auth.py
@@ -1,22 +1,30 @@
 import logging
-from typing import Optional
+from typing import NamedTuple, Optional
 
+import jwt
 import msal
 
 from powerpwn.cli.const import LOGGER_NAME, TOOL_NAME
 from powerpwn.powerdump.utils.const import API_HUB_SCOPE, AZURE_CLI_APP_ID, GRAPH_API_SCOPE, POWER_APPS_SCOPE
-from powerpwn.powerdump.utils.token_cache import TOKEN_CACHE_PATH, TokenCache, put_token, put_tokens, try_fetch_token
+from powerpwn.powerdump.utils.token_cache import TOKEN_CACHE_PATH, TokenCache, put_tokens, try_fetch_token
 
 logger = logging.getLogger(LOGGER_NAME)
 
 AZURE_CLI_REFRESH_TOKEN = "cli_refresh_token"  # nosec
 POWERAPPS_ACCESS_TOKEN = "powerapps_access_token"  # nosec
 APIHUB_ACCESS_TOKEN = "apihub_access_token"  # nosec
+TENANT = "tenant"  # nosec
 
 SCOPE_TO_TOKEN_CACHE_TYPE = {API_HUB_SCOPE: APIHUB_ACCESS_TOKEN, POWER_APPS_SCOPE: POWERAPPS_ACCESS_TOKEN}
 
 
-def acquire_token(scope: str, tenant: Optional[str] = None) -> str:
+class Auth(NamedTuple):
+    token: str
+    tenant: str
+    scope: str
+
+
+def acquire_token(scope: str, tenant: Optional[str] = None) -> Auth:
     """
     Leverage family refresh tokens to acquire a Graph API refresh token and exchange it for other required scopes
     https://github.com/secureworks/family-of-client-ids-research
@@ -54,19 +62,21 @@ def acquire_token(scope: str, tenant: Optional[str] = None) -> str:
     bearer = azure_cli_bearer_tokens_for_scope["token_type"] + " " + azure_cli_bearer_tokens_for_scope["access_token"]
     logger.info(f"Access token for {scope} acquired successfully")
 
+    extracted_tenant = tenant or __get_tenant_from_token(bearer)
     # cache refresh token for cli to use in further FOCI authentication
     # cache access token for required scope
     tokens_to_cache = [
         TokenCache(token_key=AZURE_CLI_REFRESH_TOKEN, token_val=azure_cli_app_refresh_token),
         TokenCache(SCOPE_TO_TOKEN_CACHE_TYPE[scope], bearer),
+        TokenCache(TENANT, extracted_tenant),
     ]
     put_tokens(tokens_to_cache)
     logger.info(f"Token is cached in {TOKEN_CACHE_PATH}")
 
-    return bearer
+    return Auth(token=bearer, tenant=extracted_tenant, scope=scope)
 
 
-def acquire_token_from_cached_refresh_token(scope: str, tenant: Optional[str] = None) -> str:
+def acquire_token_from_cached_refresh_token(scope: str, tenant: Optional[str] = None) -> Auth | None:
     """
     Leverage family refresh tokens to acquire a Graph API refresh token and exchange it for other required scopes
     https://github.com/secureworks/family-of-client-ids-research
@@ -79,8 +89,8 @@ def acquire_token_from_cached_refresh_token(scope: str, tenant: Optional[str] = 
     cached_refresh_token = try_fetch_token(AZURE_CLI_REFRESH_TOKEN)
 
     if not cached_refresh_token:
-        logger.info("Failed to acquire with refresh token. Fallback to device-flow")
-        return acquire_token(scope, tenant)
+        logger.info("Failed to get refresh token from cache.")
+        return None
 
     azure_cli_client = __get_msal_cli_application(tenant)
 
@@ -93,15 +103,29 @@ def acquire_token_from_cached_refresh_token(scope: str, tenant: Optional[str] = 
         )
     )
 
-    bearer = azure_cli_bearer_tokens_for_scope.get("token_type") + " " + azure_cli_bearer_tokens_for_scope.get("access_token")
+    if access_token := azure_cli_bearer_tokens_for_scope.get("access_token") is None:
+        logger.error(f"Failed to acquire token with scope='{scope}' from cached refresh token.")
+        return None
+
+    bearer = azure_cli_bearer_tokens_for_scope.get("token_type") + " " + access_token
     logger.info(f"Token for {scope} acquired from refresh token successfully.")
 
+    extracted_tenant = tenant or __get_tenant_from_token(access_token)
+
     # cache access token for required scope
-    tokens_to_cache = TokenCache(SCOPE_TO_TOKEN_CACHE_TYPE[scope], bearer)
-    put_token(tokens_to_cache)
+    tokens_to_cache = [TokenCache(SCOPE_TO_TOKEN_CACHE_TYPE[scope], bearer), TokenCache(TENANT, extracted_tenant)]
+    put_tokens(tokens_to_cache)
     logger.info(f"Token is cached in {TOKEN_CACHE_PATH}")
 
-    return bearer
+    return Auth(token=bearer, tenant=extracted_tenant, scope=scope)
+
+
+def get_cached_tenant() -> Optional[str]:
+    tenant = try_fetch_token(TENANT)
+    if not tenant:
+        logger.info("Tenant is not cached.")
+
+    return tenant
 
 
 def __get_msal_cli_application(tenant: Optional[str] = None) -> msal.PublicClientApplication:
@@ -110,3 +134,7 @@ def __get_msal_cli_application(tenant: Optional[str] = None) -> msal.PublicClien
         return msal.PublicClientApplication(AZURE_CLI_APP_ID, authority=authority, app_name=TOOL_NAME)
     else:
         return msal.PublicClientApplication(AZURE_CLI_APP_ID, app_name=TOOL_NAME)
+
+
+def __get_tenant_from_token(token: str) -> str:
+    return jwt.decode(token, algorithms=["RS256"], options={"verify_signature": False}).get("tid")

--- a/src/powerpwn/powerdump/utils/auth.py
+++ b/src/powerpwn/powerdump/utils/auth.py
@@ -59,10 +59,11 @@ def acquire_token(scope: str, tenant: Optional[str] = None) -> Auth:
         )
         raise RuntimeError(f"Something went wrong when trying to fetch tokens with scope={scope}, tenant={tenant}. Try removing cached credentials.")
 
-    bearer = azure_cli_bearer_tokens_for_scope["token_type"] + " " + azure_cli_bearer_tokens_for_scope["access_token"]
+    access_token = azure_cli_bearer_tokens_for_scope["access_token"]
+    bearer = azure_cli_bearer_tokens_for_scope["token_type"] + " " + access_token
     logger.info(f"Access token for {scope} acquired successfully")
 
-    extracted_tenant = tenant or __get_tenant_from_token(bearer)
+    extracted_tenant = tenant or __get_tenant_from_token(access_token)
     # cache refresh token for cli to use in further FOCI authentication
     # cache access token for required scope
     tokens_to_cache = [
@@ -141,3 +142,7 @@ def __get_msal_cli_application(tenant: Optional[str] = None) -> msal.PublicClien
 
 def __get_tenant_from_token(token: str) -> str:
     return jwt.decode(token, algorithms=["RS256"], options={"verify_signature": False}).get("tid")
+
+
+if __name__ == "__main__":
+    acquire_token(POWER_APPS_SCOPE)

--- a/src/powerpwn/powerdump/utils/model_loaders.py
+++ b/src/powerpwn/powerdump/utils/model_loaders.py
@@ -102,9 +102,10 @@ def load_connectors(cache_path: str, env_id: Optional[str] = None) -> Generator[
 
 
 def get_environment_ids(cache_path: str) -> List[str]:
-    if not os.path.exists(cache_path):
+    resources_path = entities_path(cache_path)
+    if not os.path.exists(cache_path) or not os.path.exists(resources_path):
         return []
-    return os.listdir(entities_path(cache_path))
+    return os.listdir(resources_path)
 
 
 def map_connection_id_to_connector_id_and_env_id(connections: Generator[Connection, None, None]) -> Dict[str, Tuple[str, str]]:

--- a/src/powerpwn/powerdump/utils/token_cache.py
+++ b/src/powerpwn/powerdump/utils/token_cache.py
@@ -10,6 +10,11 @@ class TokenCache(NamedTuple):
     token_val: str
 
 
+def clear_token_cache() -> None:
+    if os.path.exists(TOKEN_CACHE_PATH):
+        os.remove(TOKEN_CACHE_PATH)
+
+
 def put_token(token_to_cache: TokenCache) -> None:
     put_tokens([token_to_cache])
 


### PR DESCRIPTION
1) add -r to dump command, to run recon before if not run in separate command
2) add tenant level hierarchy for dump (resources and data)
3) add tenant inference from jwt if not provided in command and cache with tokens
4) add tenant inference for gui from cache, fallback to existing folder (if there is 1 tenant folder)
5) implement run gui with recon and dump
6) clear tokens on clear-cache flag